### PR TITLE
fix: script for generating JWT authentication key (fixes #6)

### DIFF
--- a/scripts/generate_jwt.py
+++ b/scripts/generate_jwt.py
@@ -50,7 +50,6 @@ def main():
             print(f"User not found ({target})", file=sys.stderr)
             return 1
 
-        # Match the app's token claims so dependencies.get_current_user works.
         token_data = {
             "sub": user.email,
             "user_id": user.id,


### PR DESCRIPTION
## Description
added  generate_jwt.py  to the scripts folder which generate access token for testing api 


## Related Issues
- Fixes #6 

## Changes Made
* while testing an access token required to access all private api. but there was no generation script in this project 
* so now i write a script which generate JWT token for accessing the private API's  while testing.
* I tested API'S with Postman 

<img width="1915" height="1045" alt="Screenshot from 2025-11-08 19-08-48" src="https://github.com/user-attachments/assets/83f50edd-08e0-4ca7-91e2-5b9789b32437" />
<img width="1915" height="1045" alt="Screenshot from 2025-11-08 19-08-27" src="https://github.com/user-attachments/assets/6dbb8006-5199-4be5-ac06-1fafe1312dea" />
