### PR TITLE
hotfix: adjust JWT expiration time

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     USE_CELERY: bool = True  # Set to False to disable Celery and use synchronous processing
     
     SECRET_KEY: str = "your-secret-key-change-in-production"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 1440
     ALGORITHM: str = "HS256"
     
     ALLOWED_HOSTS: List[str] = ["http://localhost:3000", "http://localhost:8000"]


### PR DESCRIPTION
## Description

hotfix to increase JWT access token expiration time from 30 minutes to 24 hours (1440 minutes) to prevent users from being logged out too frequently and improve session stability.

## Type of Change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [] Test updates

## Related Issues

- Fixes #49

## Changes Made

- Updated ACCESS_TOKEN_EXPIRE_MINUTES in config.py from 30 to 1440


## Testing Checklist

- [ ] Unit tests added or updated
- [ ] Integration tests pass
- [X] Manual testing completed
- [ ] Documentation updated (if applicable)
- [X] All existing tests pass

## Screenshots

N/A

## Breaking Changes
None

## Code Quality Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation to reflect my changes
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Additional Context

None